### PR TITLE
Update GNSSLocationDelivery.xsd for empty coordinates

### DIFF
--- a/S02P03_GNSSLocation/examples/GNSSLocationDeliveryNoFix.xml
+++ b/S02P03_GNSSLocation/examples/GNSSLocationDeliveryNoFix.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ITxPT S02P03 GNSSLocation service - GNSSLocation Delivery XML Example -->
+<GNSSLocationDelivery version="2.2.1">
+  <GNSSLocation>
+    <Latitude>
+      <Degree />
+      <Direction />
+    </Latitude>
+    <Longitude>
+      <Degree />
+      <Direction />
+    </Longitude>
+    <Time>08:05:30</Time>
+    <Date>2019-10-24</Date>
+    <SignalQuality>aGPS</SignalQuality>
+    <Fix>NoFix</Fix>
+    <NumberOfSatellites>0</NumberOfSatellites>
+    <GNSSType>GPS</GNSSType>
+    <GNSSCoordinateSystem>WGS84</GNSSCoordinateSystem>
+  </GNSSLocation>
+  <Extensions />
+</GNSSLocationDelivery>

--- a/S02P03_GNSSLocation/xsd/GNSSLocationDelivery.xsd
+++ b/S02P03_GNSSLocation/xsd/GNSSLocationDelivery.xsd
@@ -15,6 +15,7 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="N"/>
       <xs:enumeration value="S"/>
+      <xs:enumeration value=""/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="DegreeLatitudeType">
@@ -27,6 +28,7 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="E"/>
       <xs:enumeration value="W"/>
+      <xs:enumeration value=""/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="DegreeLongitudeType">
@@ -35,15 +37,26 @@
       <xs:maxInclusive value="+180.0"/>     
     </xs:restriction>
   </xs:simpleType>
+   <xs:simpleType name="DegreeEmptyType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="OptDegreeLatitudeType">
+    <xs:union memberTypes="DegreeLatitudeType DegreeEmptyType"/>
+  </xs:simpleType>
+  <xs:simpleType name="OptDegreeLongitudeType">
+    <xs:union memberTypes="DegreeLongitudeType DegreeEmptyType"/>
+  </xs:simpleType>
   <xs:complexType name="LatitudeType">
     <xs:sequence>
-      <xs:element name="Degree" type="DegreeLatitudeType"/>
+      <xs:element name="Degree" type="OptDegreeLatitudeType"/>
       <xs:element name="Direction" type="DirectionLatitudeType"/>
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="LongitudeType">
     <xs:sequence>
-      <xs:element name="Degree" type="DegreeLongitudeType"/>
+      <xs:element name="Degree" type="OptDegreeLongitudeType"/>
       <xs:element name="Direction" type="DirectionLongitudeType"/>
     </xs:sequence>
   </xs:complexType>


### PR DESCRIPTION
Here is a proposed addition to the GNSSLocation XSD Schema to allow validation of empty Latitude and Longitude fields as discussed in issue #2. 
This is done by using an union type to allow validation of GNSSLocationDelivery with empty Latitude and Longitude fields in case of no GPS fix. A sample xml file implementing this case is also provided.